### PR TITLE
Add post-setup script support

### DIFF
--- a/ADDED.md
+++ b/ADDED.md
@@ -2,3 +2,24 @@
 ## Newly Added Features
 
 As things get crossed off the [TODO](TODO.md) list, they will be written about here.
+
+### Post-Setup Scripts
+
+You can now specify a script or executable than will be ran after the gadgets are setup and running.
+This done by adding a new line to `options.txt`.
+
+```
+.
+.
+.
+post: /path/to/file
+```
+
+You can either pass it an absolute path as above, or a relative path from within `/boot/usbninja/`.
+
+Note that you need to have the executable bit set on whatever you point to, else it will fail!
+You can do this with a simple `chmod` as below:
+
+```
+$ sudo chmod +x /boot/usbninja/exec.sh
+```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# USB Ninja - Testing Repository - Post Gadget Setup Script Execution
+# USB Ninja
 
 The USB Ninja is an advanced USB attack development platform designed to be as simple as possible whilst leaving as many options open for development. Written in Golang, it was developed on a Raspberry Pi Zero W, but should work on any device that supports USB OTG - see the list of [Supported Devices](doc/SUPPORTED.md). It makes heavy use of [configfs](https://www.kernel.org/doc/Documentation/filesystems/configfs/configfs.txt) to configure and present the drivers to the host system. See the [FAQ](doc/FAQ.md) for more information.
 
-**WARNING: THIS IS THE TESTING BRANCH. THINGS IN THIS BRANCH ARE UNLIKELY TO WORK!**
+**Post-Setup Scripts can now be set! See [ADDED.md](ADDED.md) or [OPTIONS.md](src/OPTIONS.md) for more information!**
 
 Currently supported gadgets are:
 * [USB-To-Serial](doc/SERIAL.md)
@@ -41,6 +41,6 @@ By default, the USB Ninja will start up in `serial` mode with a baud rate of `11
 The other option is to just download and setup [Arch Linux ARM](https://archlinuxarm.org/platforms/armv6/raspberry-pi) by yourself and follow the instructions in [INSTALL.md](INSTALL.md) to compile the binaries from source and setup all the other services. The process is exactly the same as what was done to prepare the image.
 
 ## Using other gadgets
-If you want to use gadgets other than plain old `serial` (and if you're hear - you probably do), then all you need to do is edit `usbninja/options.txt` on the first partition of the MicroSD card. This corresponds to the `/boot` directory when the OS boots up.
+If you want to use gadgets other than plain old `serial` (and if you're here - you probably do), then all you need to do is edit `usbninja/options.txt` on the first partition of the MicroSD card. This corresponds to the `/boot` directory when the OS boots up.
 
 See [OPTIONS.md](doc/OPTIONS.md) and [GADGETS.md](doc/GADGETS.md) for more information.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The USB Ninja is an advanced USB attack development platform designed to be as simple as possible whilst leaving as many options open for development. Written in Golang, it was developed on a Raspberry Pi Zero W, but should work on any device that supports USB OTG - see the list of [Supported Devices](doc/SUPPORTED.md). It makes heavy use of [configfs](https://www.kernel.org/doc/Documentation/filesystems/configfs/configfs.txt) to configure and present the drivers to the host system. See the [FAQ](doc/FAQ.md) for more information.
 
-**Post-Setup Scripts can now be set! See [ADDED.md](ADDED.md) or [OPTIONS.md](src/OPTIONS.md) for more information!**
+**Post-Setup Scripts can now be set! See [ADDED.md](ADDED.md) or [OPTIONS.md](doc/OPTIONS.md) for more information!**
 
 Currently supported gadgets are:
 * [USB-To-Serial](doc/SERIAL.md)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# USB Ninja
+# USB Ninja - Testing Repository
 
 The USB Ninja is an advanced USB attack development platform designed to be as simple as possible whilst leaving as many options open for development. Written in Golang, it was developed on a Raspberry Pi Zero W, but should work on any device that supports USB OTG - see the list of [Supported Devices](doc/SUPPORTED.md). It makes heavy use of [configfs](https://www.kernel.org/doc/Documentation/filesystems/configfs/configfs.txt) to configure and present the drivers to the host system. See the [FAQ](doc/FAQ.md) for more information.
+
+**WARNING: THIS IS THE TESTING BRANCH. THINGS IN THIS BRANCH ARE UNLIKELY TO WORK!**
 
 Currently supported gadgets are:
 * [USB-To-Serial](doc/SERIAL.md)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# USB Ninja - Testing Repository
+# USB Ninja - Testing Repository - Post Gadget Setup Script Execution
 
 The USB Ninja is an advanced USB attack development platform designed to be as simple as possible whilst leaving as many options open for development. Written in Golang, it was developed on a Raspberry Pi Zero W, but should work on any device that supports USB OTG - see the list of [Supported Devices](doc/SUPPORTED.md). It makes heavy use of [configfs](https://www.kernel.org/doc/Documentation/filesystems/configfs/configfs.txt) to configure and present the drivers to the host system. See the [FAQ](doc/FAQ.md) for more information.
 

--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@
 * hid_remote gadget
 * Add "one-stop-shop" mode that deletes options.txt after execution
 * Multiple keyboard layouts
-* ~~Post gadget-setup script execution~~
+* ~~Post gadget-setup script execution~~ (See [ADDED.md](ADDED.md))
 * Add some API functions for post-setup scripts to use
 
 ## Code Changes

--- a/TODO.md
+++ b/TODO.md
@@ -5,9 +5,11 @@
 * hid_remote gadget
 * Add "one-stop-shop" mode that deletes options.txt after execution
 * Multiple keyboard layouts
-* Post gadget-setup script execution
+* ~~Post gadget-setup script execution~~
+* Add some API functions for post-setup scripts to use
 
 ## Code Changes
+* **Find a better way to distribute releases other than an 8GB image!**
 * Replace C style if IsTrue() == 0 statements with bools
 * Replace config array with map for clarity - removes need for GetOption()
 * Speed up boot time of Raspberry Pi

--- a/config/options.txt
+++ b/config/options.txt
@@ -8,6 +8,11 @@
 #   storage
 gadget: serial
 
+# Can be any script or executable on the filesystem.
+# Either an absolute path or a path relative to `/boot/usbninja/` will work
+# The executable bit must also be set. See Documentation for details.
+post: changeme
+
 # Can be any 2 byte hex value in the form of 0x????.
 vendorid: 0x1d6b
 

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -24,3 +24,7 @@ As detailed on the [ethernet](ETHERNET.md) page, the `ethernet` gadget is just a
 **6. I'm trying to use multiple gadgets at once, but it isn't working!**
 
 Multiple gadget support is currently still in testing. As far as I have seen - it seems to work just fine, but if you've found a combination that doesn't work as expected (and you have reason to think it should), then please raise an issue on this repo.
+
+**7. My `post` script isn't running even though the path is right in `options.txt`!**
+
+If you're sure the path is right (note that you can specify either an absolute path or a path relative to `/boot/usbninja/`), then you might need to set the executable bit on the file. If your script is `/boot/usbninja/exec.sh`, then you can set the executable bit with the following command: `sudo chmod +x /boot/usbninja/exec.sh`

--- a/doc/OPTIONS.md
+++ b/doc/OPTIONS.md
@@ -26,6 +26,7 @@ productname: Composite USB Device
 |`productname`|The Product Name string reported to the Host OS|Up to 32 characters long|`USB Device`|
 
 **Note: The `post` script can be either an absolute path or a path relative to `/boot/usbninja/`.**
+**Note: The `post` script must also have the executable bit set with `sudo chmod +x /path/to/file`.**
 
 ### Settings available to certain gadgets
 |Option|Gadget|Description|Format|Default Value|

--- a/doc/OPTIONS.md
+++ b/doc/OPTIONS.md
@@ -18,16 +18,16 @@ productname: Composite USB Device
 |Option|Description|Format|Default Value|
 |-|-|-|-|
 |`gadget`|The USB gadget(s) to be used|`gadget1, gadget2, etc`|`serial`|
-|`post`|An executable or script to be run after all the gadgets are setup|`file` or `/path/to/file`|none|
+|`post`|An executable or script to be run after all the gadgets are setup (See below)|`file` or `/path/to/file`|none|
 |`vendorid`|The VID presented to the Host OS|`0x????` (two hex bytes)|`0x1d6b`|
 |`productid`|The PID prestented to the Host OS|`0x????` (two hex bytes)|`0x0104`|
 |`serialnumber`|The Serial Number of the emulated device|`????????????????` (16 hex characters)|`fedcba9876543210`|
 |`manufacturer`|The Manufacturer string reported to the Host OS|Up to 32 characters long|`Generic Corp`|
 |`productname`|The Product Name string reported to the Host OS|Up to 32 characters long|`USB Device`|
 
-**Note: The `post` script can be either an absolute path or a path relative to `/boot/usbninja/`.**
+**Note:** The `post` script can be either an absolute path or a path relative to `/boot/usbninja/`.
 
-**Note: The `post` script must also have the executable bit set with `sudo chmod +x /path/to/file`.**
+**Note:** The `post` script must also have the executable bit set with `sudo chmod +x /path/to/file`.
 
 ### Settings available to certain gadgets
 |Option|Gadget|Description|Format|Default Value|

--- a/doc/OPTIONS.md
+++ b/doc/OPTIONS.md
@@ -18,11 +18,14 @@ productname: Composite USB Device
 |Option|Description|Format|Default Value|
 |-|-|-|-|
 |`gadget`|The USB gadget(s) to be used|`gadget1, gadget2, etc`|`serial`|
+|`post`|An executable or script to be run after all the gadgets are setup|`file` or `/path/to/file`|none|
 |`vendorid`|The VID presented to the Host OS|`0x????` (two hex bytes)|`0x1d6b`|
 |`productid`|The PID prestented to the Host OS|`0x????` (two hex bytes)|`0x0104`|
 |`serialnumber`|The Serial Number of the emulated device|`????????????????` (16 hex characters)|`fedcba9876543210`|
 |`manufacturer`|The Manufacturer string reported to the Host OS|Up to 32 characters long|`Generic Corp`|
 |`productname`|The Product Name string reported to the Host OS|Up to 32 characters long|`USB Device`|
+
+**Note: The `post` script can be either an absolute path or a path relative to `/boot/usbninja/`.**
 
 ### Settings available to certain gadgets
 |Option|Gadget|Description|Format|Default Value|

--- a/doc/OPTIONS.md
+++ b/doc/OPTIONS.md
@@ -26,6 +26,7 @@ productname: Composite USB Device
 |`productname`|The Product Name string reported to the Host OS|Up to 32 characters long|`USB Device`|
 
 **Note: The `post` script can be either an absolute path or a path relative to `/boot/usbninja/`.**
+
 **Note: The `post` script must also have the executable bit set with `sudo chmod +x /path/to/file`.**
 
 ### Settings available to certain gadgets

--- a/src/main.go
+++ b/src/main.go
@@ -15,7 +15,7 @@ func main() {
 	// Check which gagdet is set and branch accordingly
 	gadgets := GetGadgets()
 
-	fmt.Printf("LOG: Options set as:\n=> delay: %s\n=> vendorid: %s\n=> productid: %s\n=> serialnumber: %s\n=>manufacturer: %s\n=>productname: %s\n\n", GetOption(config, "delay"), GetOption(config, "vendorid"), GetOption(config, "productid"), GetOption(config, "serialnumber"), GetOption(config, "manufacturer"), GetOption(config, "productname"))
+	fmt.Printf("LOG: Options set as:\n=>delay: %s\n=> vendorid: %s\n=> productid: %s\n=> serialnumber: %s\n=>manufacturer: %s\n=>productname: %s\n=>post: %s\n\n", GetOption(config, "delay"), GetOption(config, "vendorid"), GetOption(config, "productid"), GetOption(config, "serialnumber"), GetOption(config, "manufacturer"), GetOption(config, "productname"), GetOption(config, "post"))
 	fmt.Printf("LOG: Gadgets set as: %v\n", gadgets)
 
 	// SetupGenericGadget
@@ -62,4 +62,8 @@ func main() {
 			HIDPostSetup(config)
 		}
 	}
+
+	// We now run the post-setup script.
+	// If none was set, then this is just "echo"
+	ShellOut(GetOption(config, "post"))
 }

--- a/src/parser.go
+++ b/src/parser.go
@@ -45,7 +45,7 @@ func GetGadgets() []string {
 
 func GetConfig() []string {
 	// Parse out options from options.txt and return as an array
-	var delay, vendorid, productid, serialnumber, manufacturer, productname, eth_hostaddr, eth_devaddr string
+	var delay, vendorid, productid, serialnumber, manufacturer, productname, eth_hostaddr, eth_devaddr, post string
 
 	// Check for options.txt locations
 	file_location := GetOptionLocation()
@@ -166,8 +166,22 @@ func GetConfig() []string {
 				slice := key_val[1:]
 				eth_devaddr = strings.TrimSpace(strings.Join(slice, ":"))
 			}
+
+			} else if key_val[0] == "post" {
+				// Check if the file exists, and set post to empty otherwise
+
+				val := strings.TrimSpace(key_val[1])
+				val2 := fmt.Sprintf("/boot/usbninja/%s", val)
+				
+				if FileExist(val) {
+					post = val
+				} else if FileExist(val2) {
+					post = val2
+				} else {
+					post = ""
+				}
+			}
 		}
-	}
 
 	if delay == "" {
 		delay = SetDefaults("delay")
@@ -193,8 +207,11 @@ func GetConfig() []string {
 	if eth_devaddr == "" {
 		eth_devaddr = SetDefaults("eth_devaddr")
 	}
+	if post == "" {
+		post = SetDefaults("post")
+	}
 
-	return []string{delay, vendorid, productid, serialnumber, manufacturer, productname, eth_hostaddr, eth_devaddr}
+	return []string{delay, vendorid, productid, serialnumber, manufacturer, productname, eth_hostaddr, eth_devaddr, post}
 }
 
 func SetDefaults(options string) string {
@@ -221,6 +238,9 @@ func SetDefaults(options string) string {
 	}
 	if options == "eth_devaddr" || options == "all" {
 		return "42:61:64:55:53:42"
+	}
+	if options == "post" || options == "all" {
+		return "echo"
 	}
 	return "error"
 }
@@ -380,6 +400,8 @@ func GetOption(config []string, option string) string {
 		return string(config[6])
 	case "eth_devaddr":
 		return string(config[7])
+	case "post":
+		return string(config[8])
 	}
 	return "error"
 }

--- a/src/parser.go
+++ b/src/parser.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"strconv"
 	"strings"
+	"fmt"
 )
 
 func GetGadgets() []string {
@@ -172,7 +173,7 @@ func GetConfig() []string {
 
 				val := strings.TrimSpace(key_val[1])
 				val2 := fmt.Sprintf("/boot/usbninja/%s", val)
-				
+
 				if FileExist(val) {
 					post = val
 				} else if FileExist(val2) {


### PR DESCRIPTION
Added support to specify a script or executable to be automatically run once the gadgets in `options.txt` are setup and running.

See [ADDED.md](https://github.com/xcellerator/usbninja/blob/master/ADDED.md) or [OPTIONS.md](https://github.com/xcellerator/usbninja/blob/master/doc/OPTIONS.md) for more information.