### PR TITLE
Add option to use alternative backing files

### DIFF
--- a/ADDED.md
+++ b/ADDED.md
@@ -23,3 +23,13 @@ You can do this with a simple `chmod` as below:
 ```
 $ sudo chmod +x /boot/usbninja/exec.sh
 ```
+
+### Alternative Backing File in `storage` mode
+
+By default, the backing file used in `storage` mode is the one located at `/lib/usbninja/storage.img`. However, you can create another one, as detailed in [STORAGE.img](src/STORAGE.img). Once done, you can specify the location of your new backing file in `options.txt` with the `storage: ` line.
+```
+.
+.
+.
+storage: /home/alarm/backing_file.img
+```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# USB Ninja
+# USB Ninja - Testing
 
 The USB Ninja is an advanced USB attack development platform designed to be as simple as possible whilst leaving as many options open for development. Written in Golang, it was developed on a Raspberry Pi Zero W, but should work on any device that supports USB OTG - see the list of [Supported Devices](doc/SUPPORTED.md). It makes heavy use of [configfs](https://www.kernel.org/doc/Documentation/filesystems/configfs/configfs.txt) to configure and present the drivers to the host system. See the [FAQ](doc/FAQ.md) for more information.
 

--- a/TODO.md
+++ b/TODO.md
@@ -7,6 +7,7 @@
 * Multiple keyboard layouts
 * ~~Post gadget-setup script execution~~ (See [ADDED.md](ADDED.md))
 * Add some API functions for post-setup scripts to use
+* ~~Add option to set alternative backing file in storage mode~~
 
 ## Code Changes
 * **Find a better way to distribute releases other than an 8GB image!**

--- a/config/options.txt
+++ b/config/options.txt
@@ -1,4 +1,6 @@
 # If any of the entries in this file are incorrectly formatted or invalid, then the defaults will be used!
+# The only required option to be set is gadget.
+# All other options are optional.
 
 # Valid gadgets are:
 #   serial
@@ -32,6 +34,10 @@ productname: USB Device
 # The first octets have to be even
 eth_hostaddr: 48:6f:73:74:50:43
 eth_devaddr: 42:61:64:55:53:42
+
+# This is only used in storage mode. If you have created your own backing file, then set it below.
+# By default, this is /lib/usbninja/storage.img
+storage: /lib/usbninja/storage.img
 
 # This is only used if in hid_payload mode. Not required and only useful if debugging a problem.
 # It's the number of milliseconds to leave in between successive HID packets sent to the Host OS.

--- a/doc/OPTIONS.md
+++ b/doc/OPTIONS.md
@@ -18,12 +18,13 @@ productname: Composite USB Device
 |Option|Description|Format|Default Value|
 |-|-|-|-|
 |`gadget`|The USB gadget(s) to be used|`gadget1, gadget2, etc`|`serial`|
-|`post`|An executable or script to be run after all the gadgets are setup (See below)|`file` or `/path/to/file`|none|
-|`vendorid`|The VID presented to the Host OS|`0x????` (two hex bytes)|`0x1d6b`|
-|`productid`|The PID prestented to the Host OS|`0x????` (two hex bytes)|`0x0104`|
-|`serialnumber`|The Serial Number of the emulated device|`????????????????` (16 hex characters)|`fedcba9876543210`|
-|`manufacturer`|The Manufacturer string reported to the Host OS|Up to 32 characters long|`Generic Corp`|
-|`productname`|The Product Name string reported to the Host OS|Up to 32 characters long|`USB Device`|
+|`post`|(Optional) An executable or script to be run after all the gadgets are setup (See below)|`file` or `/path/to/file`|none|
+|`vendorid`|(Optional) The VID presented to the Host OS|`0x????` (two hex bytes)|`0x1d6b`|
+|`productid`|(Optional) The PID prestented to the Host OS|`0x????` (two hex bytes)|`0x0104`|
+|`serialnumber`|(Optional) The Serial Number of the emulated device|`????????????????` (16 hex characters)|`fedcba9876543210`|
+|`manufacturer`|(Optional) The Manufacturer string reported to the Host OS|Up to 32 characters long|`Generic Corp`|
+|`productname`|(Optional) The Product Name string reported to the Host OS|Up to 32 characters long|`USB Device`|
+|`storage`|(Optional) An absolute path to an image file. See [HID.md](HID.md)|`/path/to/file`|`/lib/usbninja/storage.img`|
 
 **Note:** The `post` script can be either an absolute path or a path relative to `/boot/usbninja/`.
 

--- a/doc/STORAGE.md
+++ b/doc/STORAGE.md
@@ -1,16 +1,20 @@
 # USB Ninja
 ## Mass Storage Gadget
 
-The mass storage gadget is activated by putting `storage` on the `gadget: ` line in `options.txt`. By default, there is a total of 1GB available, but this can be changed by quite easily. The "storage" part of mass storage arises from the "backing file" which must be located in `/lib/usbninja/storage.img`. You can create your own backing file by following the instructions below.
+The mass storage gadget is activated by putting `storage` on the `gadget: ` line in `options.txt`. By default, there is a total of 1GB available, but this can be changed by quite easily. The "storage" part of mass storage arises from the "backing file", one of which can be located in `/lib/usbninja/storage.img`. You can create your own backing file by following the instructions below, and then set the location in `options.txt`.
+
+**Note: You do not need to do this. There is an existing empty `storage.img` file already in place in `/lib/usbninja/storage.img`.**
 
 ### Creating your own backing file
-1. Startup the USB Ninja in any mode **other** than `storage` so that we can safely modify the storage.img file.
-2. `cd` over to `/lib/usbninja/`, where `storage.img` is located.
-3. It's advisable to rename the existing `storage.img` to something else so that you can rename it back if something goes wrong; `mv storage.img storage_old.img`.
-4. You can use `dd` to create an empty file with the size you want.
+1. Startup the USB Ninja in any mode **other** than `storage`.
+2. Choose a folder you want to store the backing file in and `cd` to it. For example, `/home/alarm/`.
+3. You can use `dd` to create an empty file with the size you want.
 * E.g. For a 1GB backing file, you would run: `dd if=/dev/zero of=storage.img bs=1M count=1000`.
-5. Now you have just a raw unformatted backing file that will appear to the host OS as a block device.
-6. Set `gadget: storage` in `/boot/usbninja/options.txt`, `sync` and `reboot now` the USB Ninja to restart in mass storage mode.
+4. Now you have just a raw unformatted backing file that will appear to the host OS as a block device.
+5. Open up `/boot/usbninja/options.txt` in your editor of choice (That means vim). You will need root (or sudo).
+* Set `gadget: storage`.
+* Set `storage: /home/alarm/storage.img` (adjust to where you have saved your backing file)
+6. Run `sync` and then `reboot now`.
 7. On the **Host OS**, you should now see the raw 1GB device show up either in Linux and MacOS under `/dev` or in Windows under "Device Manager".
 8. You can format the device any way you are comfortable with, for example with a program like `gparted`.
 

--- a/src/main.go
+++ b/src/main.go
@@ -15,7 +15,7 @@ func main() {
 	// Check which gagdet is set and branch accordingly
 	gadgets := GetGadgets()
 
-	fmt.Printf("LOG: Options set as:\n=>delay: %s\n=> vendorid: %s\n=> productid: %s\n=> serialnumber: %s\n=>manufacturer: %s\n=>productname: %s\n=>post: %s\n\n", GetOption(config, "delay"), GetOption(config, "vendorid"), GetOption(config, "productid"), GetOption(config, "serialnumber"), GetOption(config, "manufacturer"), GetOption(config, "productname"), GetOption(config, "post"))
+	fmt.Printf("LOG: Options set as:\n=>delay: %s\n=> vendorid: %s\n=> productid: %s\n=> serialnumber: %s\n=>manufacturer: %s\n=>productname: %s\n=>post: %s\n=>storage: %s\n\n", GetOption(config, "delay"), GetOption(config, "vendorid"), GetOption(config, "productid"), GetOption(config, "serialnumber"), GetOption(config, "manufacturer"), GetOption(config, "productname"), GetOption(config, "post"), GetOption(config, "storage"))
 	fmt.Printf("LOG: Gadgets set as: %v\n", gadgets)
 
 	// SetupGenericGadget

--- a/src/parser.go
+++ b/src/parser.go
@@ -46,7 +46,7 @@ func GetGadgets() []string {
 
 func GetConfig() []string {
 	// Parse out options from options.txt and return as an array
-	var delay, vendorid, productid, serialnumber, manufacturer, productname, eth_hostaddr, eth_devaddr, post string
+	var delay, vendorid, productid, serialnumber, manufacturer, productname, eth_hostaddr, eth_devaddr, post, storage string
 
 	// Check for options.txt locations
 	file_location := GetOptionLocation()
@@ -181,7 +181,15 @@ func GetConfig() []string {
 				} else {
 					post = ""
 				}
-			}
+			} else if key_val[0] == "storage" {
+				// Check if the file exists, and leave empty otherwise
+
+				val := strings.TrimSpace(key_val[1])
+
+				if FileExist(val) {
+					storage = val
+				}
+				}
 		}
 
 	if delay == "" {
@@ -211,8 +219,11 @@ func GetConfig() []string {
 	if (post == "" || post == "/boot/usbninja" || post == "/boot/usbninja/") {
 		post = SetDefaults("post")
 	}
+	if storage == "" {
+		storage = SetDefaults("storage")
+	}
 
-	return []string{delay, vendorid, productid, serialnumber, manufacturer, productname, eth_hostaddr, eth_devaddr, post}
+	return []string{delay, vendorid, productid, serialnumber, manufacturer, productname, eth_hostaddr, eth_devaddr, post, storage}
 }
 
 func SetDefaults(options string) string {
@@ -242,6 +253,9 @@ func SetDefaults(options string) string {
 	}
 	if options == "post" || options == "all" {
 		return "echo"
+	}
+	if options == "storage" || options == "all" {
+		return "/lib/usbninja/storage.img"
 	}
 	return "error"
 }
@@ -403,6 +417,8 @@ func GetOption(config []string, option string) string {
 		return string(config[7])
 	case "post":
 		return string(config[8])
+	case "storage":
+		return string(config[9])
 	}
 	return "error"
 }

--- a/src/storage.go
+++ b/src/storage.go
@@ -14,7 +14,8 @@ import (
 
 func StorageGadgetSetup(config []string) {
 
-  storageimg := "/lib/usbninja/storage.img"
+  //Get the storage.img from the config. If not set or points to nonexistent file, will be default in /lib/usbninja
+  storageimg := GetOption(config,"storage")
 
   // Sprintf the directory locations
   function_loc := fmt.Sprintf("%sfunctions/mass_storage.usb0", configfs)


### PR DESCRIPTION
# Alternative backing files

In `options.txt`, you can now add a `storage: ` line to set a new backing file to be used when in `storage` mode.